### PR TITLE
fixes bug in finding the head commit of the repository

### DIFF
--- a/builtin/author.c
+++ b/builtin/author.c
@@ -173,18 +173,28 @@ void parse_range_option(char *code, int total_line, unsigned long size){
 
 void get_head_sha1(unsigned char *sha1) {
     FILE *f;
-    char fileName[50];
-    char branch[50];
-    char hex[50];    
-
-    f = fopen(".git/HEAD","r");  
-    fscanf(f, "%*s%s", branch);
+    char branch[PATH_MAX+1];
+    char fileName[PATH_MAX+1];
+    char hex[100];    
+    int n;
+    f = fopen(".git/HEAD","r");
+    assert(f!=NULL);
+    n = fscanf(f, "%s%s", hex, branch);
     fclose(f);
 
-    sprintf(fileName, ".git/%s", branch);
-    f = fopen(fileName, "r");
-    fscanf(f, "%s", hex);
-
+    if (n == 2) {
+        // read the name of the file that contains the commit id
+        assert(strcmp(hex, "ref:") == 0);
+        sprintf(fileName, ".git/%s", branch);
+        f = fopen(fileName, "r");
+        assert(f!=NULL);
+        fscanf(f, "%s", hex);
+        fclose(f);
+    } else {
+        assert(n==1); // it should be 1, the hex of the commit id
+        // any other value is invalid
+    }
+    assert(strlen(hex) == 40);
     get_sha1_hex(hex, sha1);
 }
 


### PR DESCRIPTION
the problem seems to be that the function get_head_sha1
assumes that hte file .git/HEAD contains a valid branch name.

If you checkout a given commit, you get into a detached head: for example:

----------------------------------------------------------------------
⇒  git checkout 2cfe0df
Note: checking out '2cfe0df'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.
...
----------------------------------------------------------------------

the contents of .git/HEAD are:

⇒  more .git/HEAD 
2cfe0dfa0304be2f9b6fc4508ddeb08e42d15678


this following code does not read anything on branch. Since branch is
not initialized, this code fails.

    f = fopen(".git/HEAD","r");  
    fscanf(f, "%*s%s", branch);

